### PR TITLE
Add missing scikit-learn dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies=[
     'pyarrow',
     'pyfaidx',
     'pyranges',
+    'scikit-learn',
     'tensorflow',
     # keep-sorted end
 ]


### PR DESCRIPTION
The variant_eval_examples.ipynb notebook uses sklearn for metrics (average_precision_score, roc_auc_score) but it was not listed in the project dependencies.

## Summary
- Adds `scikit-learn` to project dependencies in `pyproject.toml`

## Problem
The `variant_eval_examples.ipynb` notebook imports `sklearn.metrics` for metrics (average_precision_score, roc_auc_score) but `scikit-learn` is not listed in the project dependencies, causing `ModuleNotFoundError` after a fresh install.

## Test
- `pip install -e .` now installs scikit-learn
- `variant_eval_examples.ipynb` runs without import errors