### PR TITLE
Improve GPU installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,25 @@ Requests are processed immediately.
 
 In order to run the model, we recommend running with at least an
 [NVIDIA H100 GPU](https://docs.cloud.google.com/compute/docs/gpus#h100-gpus).
-Please ensure CUDA, cuDNN and JAX are correctly installed; the
-[JAX installation documentation](https://docs.jax.dev/en/latest/installation.html#nvidia-gpu)
-is a useful resource in this regard.
+
+#### GPU installation (NVIDIA CUDA)
+
+For local GPU support with CUDA 12, install JAX with CUDA and cuDNN:
+
+```bash
+$ pip install jax[cuda12_local] nvidia-cudnn-cu12
+```
+
+For more details, see the
+[JAX installation documentation](https://docs.jax.dev/en/latest/installation.html#nvidia-gpu).
+
+#### Running the notebooks locally
+
+If you plan to run the Colab notebooks locally, you will also need:
+
+```bash
+$ pip install ipywidgets
+```
 
 For training, we recommend running on
 [Tensor Processing Units (TPUs) v3](https://docs.cloud.google.com/tpu/docs/v3)


### PR DESCRIPTION
## Summary
- Add explicit pip commands for installing JAX with CUDA 12 support
- Document nvidia-cudnn-cu12 requirement for GPU usage
- Add ipywidgets requirement for running notebooks locally

## Problem
The current README only links to JAX installation documentation for GPU setup, which can be confusing for users. After cloning and running `pip install -e .`, users encounter errors when trying to run the model on GPU because JAX CUDA support and cuDNN are not installed.

## Changes
Added two new subsections under "Model requirements":
- **GPU installation (NVIDIA CUDA)**: Explicit commands for CUDA 12 setup
- **Running the notebooks locally**: Documents ipywidgets dependency