### PR TITLE
fix: use 0-based variant.start when centering center-mask windows

### DIFF
--- a/src/alphagenome_research/model/variant_scoring/center_mask.py
+++ b/src/alphagenome_research/model/variant_scoring/center_mask.py
@@ -47,7 +47,7 @@ def create_center_mask(
     target_resolution_width = math.ceil(width / resolution)
 
     # Determine the position of the variant in the specified resolution.
-    base_resolution_center = variant.position - interval.start
+    base_resolution_center = variant.start - interval.start
     target_resolution_center = base_resolution_center // resolution
 
     # Compute start and end indices of the variant-centered mask.

--- a/src/alphagenome_research/model/variant_scoring/center_mask_test.py
+++ b/src/alphagenome_research/model/variant_scoring/center_mask_test.py
@@ -96,6 +96,21 @@ class CenterMaskVariantScorerTest(parameterized.TestCase):
       expected_mask[expected_start:expected_end] = True
     np.testing.assert_array_equal(masks, expected_mask)
 
+  def test_create_center_mask_uses_zero_based_variant_start(self):
+    interval = genome.Interval('chr1', 100, 200)
+    variant = genome.Variant('chr1', 151, '', '')
+
+    mask = center_mask.create_center_mask(
+        interval,
+        variant,
+        width=1,
+        resolution=1,
+    )
+
+    expected = np.zeros((100, 1), dtype=bool)
+    expected[50:51] = True
+    np.testing.assert_array_equal(mask, expected)
+
   @parameterized.product(
       [
           dict(


### PR DESCRIPTION
Fixes #20

`interval.start` is a 0-based offset, so the center index should be derived from `variant.start` (0-based), not `variant.position` (1-based).

This change:
- uses `variant.start - interval.start` for the base-resolution center
- adds a regression test with a non-zero interval start to catch the previous +1 shift

Greetings, saschabuehrle