### PR TITLE
Fix splice site masks for zero-expression junctions

### DIFF
--- a/src/alphagenome_research/io/splicing.py
+++ b/src/alphagenome_research/io/splicing.py
@@ -126,10 +126,12 @@ class SpliceSiteAnnotationExtractor:
       donor_theta_rw = donors_rw[tissues].to_numpy()
       accept_theta_rw = accept_rw[tissues].to_numpy()
     else:
-      donor_theta_fw = True
-      accept_theta_fw = True
-      donor_theta_rw = True
-      accept_theta_rw = True
+      # Without tissue annotations, every junction is treated as expressed, so
+      # use a single all-True column per junction.
+      donor_theta_fw = np.ones((len(donor_idx_fw), 1), dtype=bool)
+      accept_theta_fw = np.ones((len(accept_idx_fw), 1), dtype=bool)
+      donor_theta_rw = np.ones((len(donor_idx_rw), 1), dtype=bool)
+      accept_theta_rw = np.ones((len(accept_idx_rw), 1), dtype=bool)
 
     if interval.negative_strand:
       # Then model sees negative strand data as positive strand, swap arrays.
@@ -144,10 +146,10 @@ class SpliceSiteAnnotationExtractor:
       accept_idx_rw = interval.width - 1 - accept_idx_rw
 
     splice_sites = np.zeros((interval.width, 5), dtype=bool)
-    splice_sites[donor_idx_fw, 0] = np.any(donor_theta_fw > 0)
-    splice_sites[accept_idx_fw, 1] = np.any(accept_theta_fw > 0)
-    splice_sites[donor_idx_rw, 2] = np.any(donor_theta_rw > 0)
-    splice_sites[accept_idx_rw, 3] = np.any(accept_theta_rw > 0)
+    splice_sites[donor_idx_fw, 0] = np.any(donor_theta_fw > 0, axis=1)
+    splice_sites[accept_idx_fw, 1] = np.any(accept_theta_fw > 0, axis=1)
+    splice_sites[donor_idx_rw, 2] = np.any(donor_theta_rw > 0, axis=1)
+    splice_sites[accept_idx_rw, 3] = np.any(accept_theta_rw > 0, axis=1)
     splice_sites[:, 4] = np.logical_not(np.any(splice_sites[:, :4], axis=1))
 
     return splice_sites

--- a/src/alphagenome_research/io/splicing_test.py
+++ b/src/alphagenome_research/io/splicing_test.py
@@ -80,6 +80,38 @@ class SpliceSiteAnnotationExtractorTest(parameterized.TestCase):
 
     np.testing.assert_array_equal(result, expected_sites)
 
+  def test_extract_zero_expression_junction_not_marked(self):
+    """Junctions with zero expression in every tissue are not splice sites."""
+    interval_start = 100
+    interval_end = 116
+    junction_starts = pd.DataFrame({
+        'Chromosome': 'chr1',
+        'Start': [101, 106],
+        'Strand': ['+', '+'],
+        'Tissue_0': [1, 0],
+    })
+    junction_ends = pd.DataFrame({
+        'Chromosome': 'chr1',
+        'End': [104, 109],
+        'Strand': ['+', '+'],
+        'Tissue_0': [1, 0],
+    })
+    interval = genome.Interval('chr1', interval_start, interval_end, '+')
+    extractor = splicing.SpliceSiteAnnotationExtractor(
+        junction_starts, junction_ends
+    )
+    result = extractor.extract(interval)
+
+    expected_sites = np.zeros((interval.width, 5), dtype=bool)
+    # The expressed junction (Start=101, End=104) contributes a donor at
+    # Start-1 and an acceptor at End, in 0-based coordinates within the interval.
+    expected_sites[0, 0] = True
+    expected_sites[4, 1] = True
+    # The zero-expression junction (Start=106, End=109) must not be marked.
+    expected_sites[:, 4] = np.logical_not(np.any(expected_sites[:, :4], axis=1))
+
+    np.testing.assert_array_equal(result, expected_sites)
+
   def test_tissue_mismatch_raises(self):
     junction_starts = pd.DataFrame({
         'Chromosome': 'chr1',


### PR DESCRIPTION
## Summary

`SpliceSiteAnnotationExtractor.extract()` builds a binary mask of splice sites. When tissue expression columns are present, it reduces the per-tissue expression (theta) values with `np.any(theta > 0)` over the *entire* array — all junctions and all tissues — producing a single scalar boolean. That scalar is then broadcast to every junction's position.

As a result, a junction whose expression is 0 in every tissue was still marked as a donor/acceptor splice site whenever at least one other junction in the interval had positive expression.

## Fix

Reduce over the tissue axis (`axis=1`) so each junction is marked only when at least one of its tissues has positive expression. The no-tissue branch is updated to a single all-True column per junction so the reduction stays uniform and its previous behavior (mark every junction) is preserved.

## Test

Adds `test_extract_zero_expression_junction_not_marked`, which places one expressed junction (Tissue_0=1) and one zero-expression junction (Tissue_0=0) in the interval and asserts the zero-expression junction is not marked as a splice site. This test fails on the previous implementation and passes with the fix.

## Verification

- The existing `test_extract` scenarios (both strands, with and without tissue columns) still produce identical masks.
- The new test reproduces the bug: previously both junctions were marked; now only the expressed junction is marked.